### PR TITLE
ci: update Node.js CI workflow to ignore specific paths in pull requests

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -4,10 +4,17 @@
 name: Node.js CI
 
 on:
-  push:
-    branches: ['main']
   pull_request:
     branches: ['main']
+    paths-ignore:
+      - '.github/**'
+      - '.husky/**'
+      - '.vscode/**'
+      - '.editorconfig'
+      - '.gitignore'
+      - '.prettierrc'
+      - 'LICENSE'
+      - 'README.md'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
This pull request includes a modification to the Node.js CI workflow configuration file to optimize the CI process by ignoring certain paths when running on pull requests.

Changes to Node.js CI workflow:

* [`.github/workflows/node.js.yml`](diffhunk://#diff-014228303dff9a1af15f4bbd18401f906380129b10ae2a2c62f8b8be592ff88eL7-R17): Added `paths-ignore` to exclude certain files and directories from triggering the workflow on pull requests. This includes paths like `.github/**`, `.husky/**`, `.vscode/**`, `.editorconfig`, `.gitignore`, `.prettierrc`, `LICENSE`, and `README.md`.