### PR TITLE
ci: update npm publish workflow to trigger on published releases

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -5,7 +5,7 @@ name: Node.js Package
 
 on:
   release:
-    types: [created]
+    types: [published]
 
 jobs:
   build:


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/npm-publish.yml` file. The change updates the release event type from `created` to `published` to ensure the workflow triggers correctly.

* [`.github/workflows/npm-publish.yml`](diffhunk://#diff-8a5ce8b612395836520d0655143f732d08e747af57f3cfe76b5e283600106240L8-R8): Changed the release event type from `created` to `published` to ensure the workflow triggers on the correct event.