### PR TITLE
docs: fix import statement in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 JSG is a TypeScript-first JSON schema declaration library inspired by [zod](https://zod.dev/).
 
 ```ts
-import jsg from '@socio-development/json-schema-generator'
+import jsg from '@socio-development/jsg'
 
 const usernameSchema = jsg
   .string()

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@socio-development/jsg",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "TypeScript-first JSON schema declaration library",
   "author": "CasperSocio <https://github.com/CasperSocio>",
   "license": "MIT",


### PR DESCRIPTION
This pull request includes a small change to the `README.md` file. The change updates the import statement to use the correct package name.

I also updated the library version in order to publish the fix.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L6-R6): Changed the import statement from `@socio-development/json-schema-generator` to `@socio-development/jsg`.
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the library version from `0.1.0` to `0.1.1`.