### PR TITLE
ci: add version check job to npm publish workflow

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -8,7 +8,29 @@ on:
     types: [published]
 
 jobs:
-  build:
+  check-version:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Get package version
+        id: pkg
+        run: echo "::set-output name=version::$(node -p \"require('./package.json').version\")"
+      - name: Get release version
+        id: rel
+        run: echo "::set-output name=version::${GITHUB_REF#refs/tags/}"
+      - name: Compare versions
+        run: |
+          if [ "v${{ steps.pkg.outputs.version }}" != "${{ steps.rel.outputs.version }}" ]; then
+          echo "Version mismatch: package.json version (${{ steps.pkg.outputs.version }}) does not match release version (${{ steps.rel.outputs.version }})"
+          exit 1
+          fi
+
+  test:
+    needs: check-version
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -19,8 +41,8 @@ jobs:
       - run: npm ci
       - run: npm run test:cov
 
-  publish-npm:
-    needs: build
+  publish-package:
+    needs: test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
This pull request includes significant updates to the GitHub Actions workflow for publishing npm packages. The main changes involve adding a version check step and renaming some jobs for clarity.

Improvements to the GitHub Actions workflow:

* [`.github/workflows/npm-publish.yml`](diffhunk://#diff-8a5ce8b612395836520d0655143f732d08e747af57f3cfe76b5e283600106240L11-R33): Added a `check-version` job to verify that the version in `package.json` matches the release version. This job runs before the `test` job.
* [`.github/workflows/npm-publish.yml`](diffhunk://#diff-8a5ce8b612395836520d0655143f732d08e747af57f3cfe76b5e283600106240L22-R45): Renamed the `build` job to `test` and the `publish-npm` job to `publish-package` for better clarity. The `publish-package` job now depends on the `test` job instead of the `build` job.