### PR TITLE
ci: fix npm publish workflow deprecated syntax error

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -8,7 +8,29 @@ on:
     types: [published]
 
 jobs:
-  build:
+  check-version:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Get package version
+        id: pkg
+        run: echo "::set-output name=version::$(node -p \"require('./package.json').version\")"
+      - name: Get release version
+        id: rel
+        run: echo "::set-output name=version::${GITHUB_REF#refs/tags/}"
+      - name: Compare versions
+        run: |
+          if [ "v${{ steps.pkg.outputs.version }}" != "${{ steps.rel.outputs.version }}" ]; then
+          echo "Version mismatch: package.json version (${{ steps.pkg.outputs.version }}) does not match release version (${{ steps.rel.outputs.version }})"
+          exit 1
+          fi
+
+  test:
+    needs: check-version
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -19,8 +41,8 @@ jobs:
       - run: npm ci
       - run: npm run test:cov
 
-  publish-npm:
-    needs: build
+  publish-package:
+    needs: test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -18,13 +18,13 @@ jobs:
           node-version: 20
       - name: Get package version
         id: pkg
-        run: echo "::set-output name=version::$(node -p \"require('./package.json').version\")"
+        run: echo "version=$(node -p \"require('./package.json').version\")" >> $GITHUB_ENV
       - name: Get release version
         id: rel
-        run: echo "::set-output name=version::${GITHUB_REF#refs/tags/}"
+        run: echo "version=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
       - name: Compare versions
         run: |
-          if [ "v${{ steps.pkg.outputs.version }}" != "${{ steps.rel.outputs.version }}" ]; then
+          if [ "${{ steps.pkg.outputs.version }}" != "${{ steps.rel.outputs.version }}" ]; then
           echo "Version mismatch: package.json version (${{ steps.pkg.outputs.version }}) does not match release version (${{ steps.rel.outputs.version }})"
           exit 1
           fi


### PR DESCRIPTION
This pull request includes changes to the `.github/workflows/npm-publish.yml` file to update the way environment variables are set during the workflow. The most important changes are:

Workflow updates:

* Changed the method of setting the `version` environment variable for both package version and release version to use `$GITHUB_ENV` instead of `::set-output`.
* Removed the prefix 'v' from the version comparison to ensure the package version and release version are directly compared without the 'v' prefix.