### PR TITLE
ci: enhance npm publish workflow with version checks and add semver script

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -7,25 +7,35 @@ on:
   release:
     types: [published]
 
+env:
+  PKG_VERSION: ''
+  RELEASE_VERSION: ''
+
 jobs:
   check-version:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
+          cache: 'npm'
           node-version: 20
+
       - name: Get package version
         id: pkg
-        run: echo "version=$(node -p \"require('./package.json').version\")" >> $GITHUB_ENV
+        run: echo "PKG_VERSION=$(npm run semver --silent)" >> $GITHUB_ENV
+        shell: bash
+
       - name: Get release version
         id: rel
-        run: echo "version=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+
       - name: Compare versions
         run: |
-          if [ "${{ steps.pkg.outputs.version }}" != "${{ steps.rel.outputs.version }}" ]; then
-          echo "Version mismatch: package.json version (${{ steps.pkg.outputs.version }}) does not match release version (${{ steps.rel.outputs.version }})"
+          if [ "v${{ env.PKG_VERSION }}" != "${{ env.RELEASE_VERSION }}" ]; then
+          echo "Version mismatch: package.json version (${{ env.PKG_VERSION }}) does not match release version (${{ env.RELEASE_VERSION }})"
           exit 1
           fi
 

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -8,7 +8,29 @@ on:
     types: [published]
 
 jobs:
-  build:
+  check-version:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Get package version
+        id: pkg
+        run: echo "::set-output name=version::$(node -p \"require('./package.json').version\")"
+      - name: Get release version
+        id: rel
+        run: echo "::set-output name=version::${GITHUB_REF#refs/tags/}"
+      - name: Compare versions
+        run: |
+          if [ "v${{ steps.pkg.outputs.version }}" != "${{ steps.rel.outputs.version }}" ]; then
+          echo "Version mismatch: package.json version (${{ steps.pkg.outputs.version }}) does not match release version (${{ steps.rel.outputs.version }})"
+          exit 1
+          fi
+
+  test:
+    needs: check-version
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -19,8 +41,8 @@ jobs:
       - run: npm ci
       - run: npm run test:cov
 
-  publish-npm:
-    needs: build
+  publish-package:
+    needs: test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -18,13 +18,13 @@ jobs:
           node-version: 20
       - name: Get package version
         id: pkg
-        run: echo "::set-output name=version::$(node -p \"require('./package.json').version\")"
+        run: echo "version=$(node -p \"require('./package.json').version\")" >> $GITHUB_ENV
       - name: Get release version
         id: rel
-        run: echo "::set-output name=version::${GITHUB_REF#refs/tags/}"
+        run: echo "version=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
       - name: Compare versions
         run: |
-          if [ "v${{ steps.pkg.outputs.version }}" != "${{ steps.rel.outputs.version }}" ]; then
+          if [ "${{ steps.pkg.outputs.version }}" != "${{ steps.rel.outputs.version }}" ]; then
           echo "Version mismatch: package.json version (${{ steps.pkg.outputs.version }}) does not match release version (${{ steps.rel.outputs.version }})"
           exit 1
           fi

--- a/jest.config.js
+++ b/jest.config.js
@@ -19,6 +19,7 @@ module.exports = {
     '<rootDir>/dist',
     '<rootDir>/playground',
     '<rootDir>/node_modules',
+    '<rootDir>/scripts',
     '<rootDir>/jest.config.js',
     '<rootDir>/LICENSE',
     '<rootDir>/package.json',

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "dev": "tsx playground/main.ts",
     "format": "prettier --write .",
     "prepare": "husky",
+    "semver": "tsx scripts/semver.ts",
     "test:cov": "jest --coverage",
     "test:watch": "jest --watch",
     "test": "jest"

--- a/scripts/semver.ts
+++ b/scripts/semver.ts
@@ -1,0 +1,3 @@
+import { version } from '../package.json'
+
+console.log(version)


### PR DESCRIPTION
This pull request includes several changes to the GitHub Actions workflow and the project's scripts. The most important changes involve setting up environment variables for versioning, adding a new script to retrieve the package version, and modifying the workflow to use these new variables.

### Workflow improvements:
* [`.github/workflows/npm-publish.yml`](diffhunk://#diff-8a5ce8b612395836520d0655143f732d08e747af57f3cfe76b5e283600106240R10-R38): Added environment variables `PKG_VERSION` and `RELEASE_VERSION` to store version information and updated the steps to use these variables for version comparison.

### Script updates:
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R34): Added a new script `semver` to retrieve the package version using the `scripts/semver.ts` file.
* [`scripts/semver.ts`](diffhunk://#diff-198c6a7b470078b4737cd1bfafeb7ac07650010e8ef78058b6623dacc92dfe37R1-R3): Created a new script to log the current package version from `package.json`.