### PR TITLE
feat: add support for the JSON schema number type

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,21 +1,31 @@
 import { JsgBoolean } from './boolean'
 import jsg from './index'
+import { JsgNumber } from './number'
 import { JsgString } from './string'
 
 describe('jsg', () => {
-  describe('string', () => {
-    it('returns a JsgString instance', () => {
-      const actual = jsg.string()
-      const expected = new JsgString()
+  describe('boolean', () => {
+    it('returns a JsgBoolean instance', () => {
+      const actual = jsg.boolean()
+      const expected = new JsgBoolean()
 
       expect(actual).toEqual(expected)
     })
   })
 
-  describe('boolean', () => {
-    it('returns a JsgBoolean instance', () => {
-      const actual = jsg.boolean()
-      const expected = new JsgBoolean()
+  describe('number', () => {
+    it('returns a JsgNumber instance', () => {
+      const actual = jsg.number()
+      const expected = new JsgNumber()
+
+      expect(actual).toEqual(expected)
+    })
+  })
+
+  describe('string', () => {
+    it('returns a JsgString instance', () => {
+      const actual = jsg.string()
+      const expected = new JsgString()
 
       expect(actual).toEqual(expected)
     })

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,9 @@
 import { JsgBoolean } from './boolean'
+import { JsgNumber } from './number'
 import { JsgString } from './string'
 
 export default {
   boolean: () => new JsgBoolean(),
+  number: () => new JsgNumber(),
   string: () => new JsgString(),
 }

--- a/src/number.test.ts
+++ b/src/number.test.ts
@@ -1,0 +1,133 @@
+import { JsgNumber } from './number'
+
+describe('JsgNumber', () => {
+  describe('constructor', () => {
+    it('sets base type property to number', () => {
+      const el = new JsgNumber()
+
+      const actual = el['_baseProps'].type
+      const expected = 'number'
+
+      expect(actual).toBe(expected)
+    })
+
+    it('sets props to empty object', () => {
+      const el = new JsgNumber()
+
+      const actual = el['_props']
+      const expected = {}
+
+      expect(actual).toEqual(expected)
+    })
+  })
+
+  describe('exclusiveMaximum', () => {
+    it('sets exclusiveMaximum property', () => {
+      const el = new JsgNumber()
+
+      el.exclusiveMaximum(10)
+
+      const actual = el['_props'].exclusiveMaximum
+      const expected = 10
+
+      expect(actual).toBe(expected)
+    })
+
+    it('returns this', () => {
+      const el = new JsgNumber()
+
+      const actual = el.exclusiveMaximum(10)
+      const expected = el
+
+      expect(actual).toBe(expected)
+    })
+  })
+
+  describe('exclusiveMinimum', () => {
+    it('sets exclusiveMinimum property', () => {
+      const el = new JsgNumber()
+
+      el.exclusiveMinimum(10)
+
+      const actual = el['_props'].exclusiveMinimum
+      const expected = 10
+
+      expect(actual).toBe(expected)
+    })
+
+    it('returns this', () => {
+      const el = new JsgNumber()
+
+      const actual = el.exclusiveMinimum(10)
+      const expected = el
+
+      expect(actual).toBe(expected)
+    })
+  })
+
+  describe('maximum', () => {
+    it('sets maximum property', () => {
+      const el = new JsgNumber()
+
+      el.maximum(10)
+
+      const actual = el['_props'].maximum
+      const expected = 10
+
+      expect(actual).toBe(expected)
+    })
+
+    it('returns this', () => {
+      const el = new JsgNumber()
+
+      const actual = el.maximum(10)
+      const expected = el
+
+      expect(actual).toBe(expected)
+    })
+  })
+
+  describe('minimum', () => {
+    it('sets minimum property', () => {
+      const el = new JsgNumber()
+
+      el.minimum(10)
+
+      const actual = el['_props'].minimum
+      const expected = 10
+
+      expect(actual).toBe(expected)
+    })
+
+    it('returns this', () => {
+      const el = new JsgNumber()
+
+      const actual = el.minimum(10)
+      const expected = el
+
+      expect(actual).toBe(expected)
+    })
+  })
+
+  describe('multipleOf', () => {
+    it('sets multipleOf property', () => {
+      const el = new JsgNumber()
+
+      el.multipleOf(10)
+
+      const actual = el['_props'].multipleOf
+      const expected = 10
+
+      expect(actual).toBe(expected)
+    })
+
+    it('returns this', () => {
+      const el = new JsgNumber()
+
+      const actual = el.multipleOf(10)
+      const expected = el
+
+      expect(actual).toBe(expected)
+    })
+  })
+})

--- a/src/number.ts
+++ b/src/number.ts
@@ -1,0 +1,65 @@
+import JsgPrimitive from './primitive'
+
+/**
+ * Properties available for the JSON schema number type.
+ */
+type JsgNumberProps = {
+  exclusiveMaximum?: number
+  exclusiveMinimum?: number
+  maximum?: number
+  minimum?: number
+  multipleOf?: number
+}
+
+/**
+ * A class for defining JSON Schema Generator number types.
+ */
+export class JsgNumber extends JsgPrimitive<JsgNumberProps> {
+  override _props: JsgNumberProps
+
+  constructor() {
+    super('number')
+
+    this._props = {}
+  }
+
+  /**
+   * Makes the maximum property exclusive.
+   */
+  exclusiveMaximum(value: number): this {
+    this._props.exclusiveMaximum = value
+    return this
+  }
+
+  /**
+   * Makes the minimum property exclusive.
+   */
+  exclusiveMinimum(value: number): this {
+    this._props.exclusiveMinimum = value
+    return this
+  }
+
+  /**
+   * The maximum numerical value, inclusive by default.
+   */
+  maximum(value: number): this {
+    this._props.maximum = value
+    return this
+  }
+
+  /**
+   * The minimum numerical value, inclusive by default.
+   */
+  minimum(value: number): this {
+    this._props.minimum = value
+    return this
+  }
+
+  /**
+   * A number that should cleanly divide the current value (i.e. have no remainder).
+   */
+  multipleOf(value: number): this {
+    this._props.multipleOf = value
+    return this
+  }
+}


### PR DESCRIPTION
This pull request introduces a new class `JsgNumber` to the codebase, along with its associated tests and integration into the existing structure. The most important changes include the addition of the `JsgNumber` class, updating the `index.ts` file to include the new class, and adding comprehensive tests for the `JsgNumber` class.

New class addition:

* [`src/number.ts`](diffhunk://#diff-c789a6b649be67d6cd62cfd922484658bb99aa5a9969bcd61a0ea583be3a39b5R1-R65): Added the `JsgNumber` class, which defines various properties and methods for handling JSON schema number types.

Integration into existing structure:

* [`src/index.ts`](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R2-R7): Updated to include the `JsgNumber` class in the exported object, allowing it to be used throughout the project.

Testing:

* [`src/number.test.ts`](diffhunk://#diff-0bdccdac28e77d9cde69abfeb7bd2b638b110b987f821ade0f3b3da37676f5d8R1-R133): Added tests for the `JsgNumber` class, covering its constructor and methods such as `exclusiveMaximum`, `exclusiveMinimum`, `maximum`, `minimum`, and `multipleOf`.
* [`src/index.test.ts`](diffhunk://#diff-258035e5968f6bf645400d417f310218d7d9a9a10606a3c34e7f55db193f58f3R3-R28): Modified tests to include the `JsgNumber` class, ensuring it returns an instance of `JsgNumber` as expected.