### PR TITLE
feat: add support for the JSON schema array type

### DIFF
--- a/src/array.test.ts
+++ b/src/array.test.ts
@@ -1,0 +1,56 @@
+import { JsgArray } from './array'
+
+describe('JsgArray', () => {
+  describe('constructor', () => {
+    it('sets base type property to array', () => {
+      const el = new JsgArray()
+
+      const actual = el['_baseProps'].type
+      const expected = 'array'
+
+      expect(actual).toBe(expected)
+    })
+
+    it('sets props to empty object', () => {
+      const el = new JsgArray()
+
+      const actual = el['_props']
+      const expected = {}
+
+      expect(actual).toEqual(expected)
+    })
+  })
+
+  describe('uniqueItems', () => {
+    it('sets uniqueItems property to true (by default)', () => {
+      const el = new JsgArray()
+
+      el.uniqueItems()
+
+      const actual = el['_props'].uniqueItems
+      const expected = true
+
+      expect(actual).toBe(expected)
+    })
+
+    it('sets uniqueItems property to false', () => {
+      const el = new JsgArray()
+
+      el.uniqueItems(false)
+
+      const actual = el['_props'].uniqueItems
+      const expected = false
+
+      expect(actual).toBe(expected)
+    })
+
+    it('returns this', () => {
+      const el = new JsgArray()
+
+      const actual = el.uniqueItems()
+      const expected = el
+
+      expect(actual).toBe(expected)
+    })
+  })
+})

--- a/src/array.ts
+++ b/src/array.ts
@@ -1,0 +1,30 @@
+import JsgPrimitive from './primitive'
+
+/**
+ * Properties available for the JSON schema array type.
+ */
+type JsgArrayProps = {
+  uniqueItems?: boolean
+}
+
+/**
+ * A class for defining JSON Schema Generator array types.
+ */
+export class JsgArray extends JsgPrimitive<JsgArrayProps> {
+  override _props: JsgArrayProps
+
+  constructor() {
+    super('array')
+
+    this._props = {}
+  }
+
+  /**
+   * If all of the items in the array must be unique.
+   * @param val Whether the items must be unique (default: true).
+   */
+  uniqueItems(value = true): this {
+    this._props.uniqueItems = value
+    return this
+  }
+}

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,9 +1,19 @@
+import { JsgArray } from './array'
 import { JsgBoolean } from './boolean'
 import jsg from './index'
 import { JsgNumber } from './number'
 import { JsgString } from './string'
 
 describe('jsg', () => {
+  describe('array', () => {
+    it('returns a JsgArray instance', () => {
+      const actual = jsg.array()
+      const expected = new JsgArray()
+
+      expect(actual).toEqual(expected)
+    })
+  })
+
   describe('boolean', () => {
     it('returns a JsgBoolean instance', () => {
       const actual = jsg.boolean()

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,10 @@
+import { JsgArray } from './array'
 import { JsgBoolean } from './boolean'
 import { JsgNumber } from './number'
 import { JsgString } from './string'
 
 export default {
+  array: () => new JsgArray(),
   boolean: () => new JsgBoolean(),
   number: () => new JsgNumber(),
   string: () => new JsgString(),


### PR DESCRIPTION
This pull request introduces a new `JsgArray` class for defining JSON Schema Generator array types, along with corresponding tests and updates to the main export file. The most important changes include the implementation of the `JsgArray` class, the addition of tests for this class, and updates to the main export file to include the new class.

### Implementation of `JsgArray` class:
* [`src/array.ts`](diffhunk://#diff-faff547418b4c30b0b51e2ecea9d62b0bf475f12108f08c5c6adbb061dec2f89R1-R30): Added the `JsgArray` class, which extends `JsgPrimitive` and includes a constructor and a `uniqueItems` method to handle array-specific properties.

### Addition of tests for `JsgArray` class:
* [`src/array.test.ts`](diffhunk://#diff-ac8b034a2b50033cca8ce2afead99a5265a3e25849bd13a27e3486db97abfeb5R1-R56): Added tests to verify the functionality of the `JsgArray` class, including its constructor and `uniqueItems` method.

### Updates to main export file:
* [`src/index.ts`](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R1-R7): Updated the main export file to include the `JsgArray` class in the default export object.
* [`src/index.test.ts`](diffhunk://#diff-258035e5968f6bf645400d417f310218d7d9a9a10606a3c34e7f55db193f58f3R1-R16): Added a test to ensure that the `jsg.array` function returns an instance of `JsgArray`.