### PR TITLE
refactor: change build output directory from dist to lib

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 !.vscode/extensions.json
 coverage
 dist
+lib
 node_modules

--- a/jest.config.js
+++ b/jest.config.js
@@ -17,6 +17,7 @@ module.exports = {
     '<rootDir>/.vscode',
     '<rootDir>/coverage',
     '<rootDir>/dist',
+    '<rootDir>/lib',
     '<rootDir>/playground',
     '<rootDir>/node_modules',
     '<rootDir>/scripts',

--- a/package.json
+++ b/package.json
@@ -17,17 +17,17 @@
   ],
   "exports": {
     ".": {
-      "import": "./dist/index.js",
-      "require": "./dist/index.js"
+      "import": "./lib/index.js",
+      "require": "./lib/index.js"
     }
   },
   "files": [
-    "dist"
+    "lib"
   ],
-  "main": "./dist/index.js",
-  "types": "./dist/index.d.ts",
+  "main": "./lib/index.js",
+  "types": "./lib/index.d.ts",
   "scripts": {
-    "build": "rm -rf dist && tsc --build",
+    "build": "rm -rf lib && tsc --build",
     "dev": "tsx playground/main.ts",
     "format": "prettier --write .",
     "prepare": "husky",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -38,7 +38,8 @@
     "declaration": true,
 
     "jsx": "preserve",
-    "outDir": "lib"
+    "outDir": "lib",
+    "skipLibCheck": true
   },
   "include": ["src/**/*"],
   "exclude": ["coverage", "dist", "lib", "node_modules", "src/**/*.test.ts"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -38,8 +38,8 @@
     "declaration": true,
 
     "jsx": "preserve",
-    "outDir": "dist"
+    "outDir": "lib"
   },
   "include": ["src/**/*"],
-  "exclude": ["coverage", "dist", "node_modules", "src/**/*.test.ts"]
+  "exclude": ["coverage", "dist", "lib", "node_modules", "src/**/*.test.ts"]
 }


### PR DESCRIPTION
This pull request includes changes to the `package.json` file to update the build output directory from `dist` to `lib`. The most important changes include modifying the export paths, the files array, and the main and types paths.

Changes to build output directory:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L20-R30): Updated export paths from `./dist/index.js` to `./lib/index.js` and from `./dist/index.d.ts` to `./lib/index.d.ts`.
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L20-R30): Changed the `files` array to include `lib` instead of `dist`.
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L20-R30): Updated the `main` and `types` paths from `./dist/index.js` and `./dist/index.d.ts` to `./lib/index.js` and `./lib/index.d.ts`.
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L20-R30): Modified the `build` script to remove `lib` instead of `dist` before building.