### PR TITLE
Implement flag-based behaviour

### DIFF
--- a/src/__tests__/primitive.test.ts
+++ b/src/__tests__/primitive.test.ts
@@ -1,22 +1,6 @@
 import { JsgString } from '../string'
 
 describe('JsgPrimitive', () => {
-  describe('constructor', () => {
-    it('sets _optional to false by default', () => {
-      const el = new JsgString()
-
-      expect(el['_optional']).toBe(false)
-    })
-
-    it('does not add "optional" to _baseProps', () => {
-      const el = new JsgString()
-      const baseProps = el['_baseProps']
-      const basePropsKeys = Object.keys(baseProps)
-
-      expect(basePropsKeys).not.toContain('optional')
-    })
-  })
-
   describe('description', () => {
     it('sets _baseProps.description to "A string"', () => {
       const el = new JsgString().description('A string')
@@ -26,10 +10,16 @@ describe('JsgPrimitive', () => {
   })
 
   describe('optional', () => {
-    it('sets _optional to true', () => {
+    it('adds JsgFlag.OPTIONAL to _flags', () => {
       const el = new JsgString().optional()
 
-      expect(el['_optional']).toBe(true)
+      expect(el['_flags']).toEqual(['opt'])
+    })
+
+    it('does not add JsgFlag.OPTIONAL to _flags if it already exists', () => {
+      const el = new JsgString().optional().optional()
+
+      expect(el['_flags']).toEqual(['opt'])
     })
   })
 

--- a/src/enums.ts
+++ b/src/enums.ts
@@ -1,0 +1,9 @@
+/**
+ * Flags that can be applied to `JsgPrimitive['_flags']`.
+ */
+export enum JsgFlag {
+  /**
+   * Indicates that the property key should not be included in `JsgObject['_props'].required`.
+   */
+  OPTIONAL = 'opt',
+}

--- a/src/object.ts
+++ b/src/object.ts
@@ -1,3 +1,4 @@
+import { JsgFlag } from './enums'
 import JsgPrimitive from './primitive'
 import type { JsgAny, JsgAnyProps, JsgObjectProps, JsgProps } from './types'
 
@@ -49,7 +50,7 @@ export class JsgObject extends JsgPrimitive<JsgObjectProps> {
 
   private get _required(): string[] | undefined {
     const requiredKeys = this._properties
-      .filter(({ value }) => !value['_optional'])
+      .filter(({ value }) => !value['_flags'].includes(JsgFlag.OPTIONAL))
       .map(({ key }) => key)
 
     return requiredKeys.length > 0 ? requiredKeys : undefined

--- a/src/primitive.ts
+++ b/src/primitive.ts
@@ -1,14 +1,23 @@
+import { JsgFlag } from './enums'
 import type { JsgBaseProps, JsgBaseType, JsgProps } from './types'
 
 export default abstract class JsgPrimitive<T> {
+  /**
+   * The base properties available to every JSON schema primitive.
+   */
   private _baseProps: JsgBaseProps
-  // @ts-ignore Used by JsgObject to determine if a property is optional
-  private _optional: boolean
+  /**
+   * Flags used to modify the behavior of the element.
+   */
+  private _flags: JsgFlag[]
+  /**
+   * The properties specific to the primitive type.
+   */
   abstract _props: T
 
   constructor(type: JsgBaseType) {
     this._baseProps = { type }
-    this._optional = false
+    this._flags = []
   }
 
   /**
@@ -24,7 +33,9 @@ export default abstract class JsgPrimitive<T> {
    * Prevents the element from being required in the parent object.
    */
   optional(): this {
-    this._optional = true
+    if (!this._flags.includes(JsgFlag.OPTIONAL)) {
+      this._flags.push(JsgFlag.OPTIONAL)
+    }
     return this
   }
 


### PR DESCRIPTION
This pull request includes significant changes to the `JsgPrimitive` class and its related tests to improve the handling of optional properties by using flags. The main changes involve replacing the `_optional` property with a `_flags` array and introducing the `JsgFlag` enum to manage these flags.

closes #16 

### Improvements to handling of optional properties:

* [`src/enums.ts`](diffhunk://#diff-00310f3f832445de900d07b99183266cabc84aa21246ec7f1d136635b3108f79R1-R9): Introduced the `JsgFlag` enum to define flags that can be applied to `JsgPrimitive['_flags']`.
* [`src/primitive.ts`](diffhunk://#diff-642515c3145e6d54cb44d000950a72f8fdafee5bf7cad0634a08087ddcde5773R1-R20): Replaced the `_optional` property with a `_flags` array and updated the `optional` method to use the `JsgFlag.OPTIONAL` flag. [[1]](diffhunk://#diff-642515c3145e6d54cb44d000950a72f8fdafee5bf7cad0634a08087ddcde5773R1-R20) [[2]](diffhunk://#diff-642515c3145e6d54cb44d000950a72f8fdafee5bf7cad0634a08087ddcde5773L27-R38)
* [`src/object.ts`](diffhunk://#diff-48beee939efb52513592b4eec6486a4e55244a1a990e79fdef0cacbbd45f3e02L52-R53): Updated the `_required` method in `JsgObject` to check for the `JsgFlag.OPTIONAL` flag instead of the `_optional` property.

### Updates to tests:

* [`src/__tests__/primitive.test.ts`](diffhunk://#diff-d47870ea8dd3fc29f2c80ae6d79ec7860967b801fa67d89a00a93bc5c1078b9bL4-L19): Removed tests for the `_optional` property and added tests for the new `_flags` array and `JsgFlag.OPTIONAL` flag. [[1]](diffhunk://#diff-d47870ea8dd3fc29f2c80ae6d79ec7860967b801fa67d89a00a93bc5c1078b9bL4-L19) [[2]](diffhunk://#diff-d47870ea8dd3fc29f2c80ae6d79ec7860967b801fa67d89a00a93bc5c1078b9bL29-R22)