### PR TITLE
ci: rename release drafter config

### DIFF
--- a/.github/release-drafter-config.yml
+++ b/.github/release-drafter-config.yml
@@ -27,7 +27,3 @@ version-resolver:
   default: patch
 exclude-labels:
 - 'skip-changelog'
-template: |
-  ## Changes
-
-  $CHANGES

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -27,7 +27,6 @@ jobs:
       # Drafts your next Release notes as Pull Requests are merged into "main"
       - uses: release-drafter/release-drafter@v6
         with:
-          config-name: release-drafter.yml
-          prerelease: true
+          config-name: release-drafter-config.yml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request includes changes to the release drafter configuration and workflow files. The most important changes are:

### Configuration Updates:
* Renamed `.github/release-drafter.yml` to `.github/release-drafter-config.yml` and removed the `template` section.

### Workflow Updates:
* Updated the `release-drafter` action configuration to use the new `release-drafter-config.yml` file and removed the `prerelease` option.