### PR TITLE
ci: add template to release-dreaft-config.yml

### DIFF
--- a/.github/release-drafter-config.yml
+++ b/.github/release-drafter-config.yml
@@ -27,3 +27,7 @@ version-resolver:
   default: patch
 exclude-labels:
 - 'skip-changelog'
+template: |
+  ## Changes
+
+  $CHANGES


### PR DESCRIPTION
This pull request includes a change to the `.github/release-drafter-config.yml` file to improve the release notes template by adding a section for changes.

* [`.github/release-drafter-config.yml`](diffhunk://#diff-b646afc744b5c8c7eab3f0ed3b523329e09a4c08ea32f1c56aefb35ac3e009f2R30-R33): Added a template for release notes that includes a "Changes" section and a placeholder for listing the changes.