### PR TITLE
ci: remove need for semver script

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,49 +1,69 @@
-# This workflow will run tests using node and then publish a package to GitHub Packages when a release is created
+# This workflow will run tests using node and then publish a package to GitHub Packages when a release is published
 # For more information see: https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages
 
-name: Node.js Package
+name: Publish NPM Package
 
 on:
   release:
     types: [published]
 
-env:
-  PKG_VERSION: ''
-  RELEASE_VERSION: ''
-
 jobs:
-  check-version:
+  get-versions:
+    name: Get versions
+
     runs-on: ubuntu-latest
+
+    outputs:
+      PKG_VERSION: ${{ steps.extract-package-version.outputs.PKG_VERSION }}
+      RELEASE_VERSION: ${{ steps.extract-release-version.outputs.RELEASE_VERSION }}
+
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
 
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          cache: 'npm'
-          node-version: 20
+      - name: Extract package version
+        id: extract-package-version
+        shell: bash
+        run: |
+          ROOT_PATH="${1-.}"
+          PKG_JSON_PATH="${ROOT_PATH}/package.json"
+          PKG_VERSION=$(jq -r '.version' < "${PKG_JSON_PATH}")
+          echo "PKG_VERSION=v${PKG_VERSION}" >> $GITHUB_OUTPUT
 
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Get package version
-        id: pkg
-        run: echo "PKG_VERSION=$(npm run semver --silent)" >> $GITHUB_ENV
+      - name: Extract release version
+        id: extract-release-version
+        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
         shell: bash
 
-      - name: Get release version
-        id: rel
-        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
-
-      - name: Compare versions
+      - name: Print extracted versions
+        shell: bash
         run: |
-          if [ "v${{ env.PKG_VERSION }}" != "${{ env.RELEASE_VERSION }}" ]; then
-          echo "Version mismatch: package.json version (${{ env.PKG_VERSION }}) does not match release version (${{ env.RELEASE_VERSION }})"
-          exit 1
+          echo "Package version is ${{ steps.extract-package-version.outputs.PKG_VERSION }}"
+          echo "Release version is ${{ steps.extract-release-version.outputs.RELEASE_VERSION }}"
+  
+  compare-versions:
+    name: Compare versions
+
+    needs: get-versions
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Compare versions
+        env:
+          PKG_VERSION: ${{ needs.get-versions.outputs.PKG_VERSION }}
+          RELEASE_VERSION: ${{ needs.get-versions.outputs.RELEASE_VERSION }}
+        run: |
+          if [ "${{ env.PKG_VERSION }}" != "${{ env.RELEASE_VERSION }}" ]; then
+            echo "Version mismatch: package.json version (${{ env.PKG_VERSION }}) does not match release version (${{ env.RELEASE_VERSION }})"
+            exit 1
+          else
+            echo "Version match: package.json version (${{ env.PKG_VERSION }}) matches release version (${{ env.RELEASE_VERSION }})"
           fi
+        shell: bash
 
   test:
-    needs: check-version
+    needs: compare-versions
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "dev": "tsx playground/main.ts",
     "format": "prettier --write .",
     "prepare": "husky",
-    "semver": "tsx scripts/semver.ts",
     "test:cov": "jest --coverage",
     "test:watch": "jest --watch",
     "test": "jest"

--- a/scripts/semver.ts
+++ b/scripts/semver.ts
@@ -1,3 +1,0 @@
-import { version } from '../package.json'
-
-console.log(version)


### PR DESCRIPTION
This pull request includes significant changes to the GitHub Actions workflow for publishing NPM packages, as well as some cleanup in the `package.json` and removal of an unused script. The most important changes include renaming and restructuring the workflow, extracting and comparing versions more clearly, and removing the `semver` script.

Improvements to GitHub Actions workflow:

* [`.github/workflows/npm-publish.yml`](diffhunk://#diff-8a5ce8b612395836520d0655143f732d08e747af57f3cfe76b5e283600106240L1-R66): Renamed workflow to "Publish NPM Package" and restructured the job steps to extract and compare package and release versions more clearly.

Cleanup and simplification:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L34): Removed the `semver` script from the `scripts` section as it is no longer needed.
* [`scripts/semver.ts`](diffhunk://#diff-198c6a7b470078b4737cd1bfafeb7ac07650010e8ef78058b6623dacc92dfe37L1-L3): Removed the `semver.ts` script which was used to print the package version.